### PR TITLE
feat: 使用 contrib.rocks 自动生成贡献者列表

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -1,0 +1,19 @@
+name: Contributors
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # 每周日更新一次
+  push:
+    branches:
+      - main
+
+jobs:
+  contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Update Contributors Image
+        run: |
+          echo "Contributors image is automatically generated from https://contrib.rocks"
+          echo "No action needed - the image updates automatically"

--- a/README.md
+++ b/README.md
@@ -418,11 +418,13 @@ CHROME_PATH="/usr/bin/google-chrome"
 
 ---
 
-## 🙏 鸣谢
+## 🙏 贡献者
 
-感谢以下贡献者为项目的发展做出的贡献：
+感谢所有为项目做出贡献的人！
 
-- **[@leebuooooo](https://github.com/leebuooooo)** (郭立ee)
+<a href="https://github.com/aki66938/xhs-toolkit/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=aki66938/xhs-toolkit" />
+</a>
 
 如果您也想为项目做出贡献，欢迎提交 Pull Request 或 Issue！
 


### PR DESCRIPTION
## 变更说明

本 PR 解决了贡献者列表手动维护的问题，采用了自动化方案。

## 主要变更

- 🔄 使用 [contrib.rocks](https://contrib.rocks) 服务自动生成贡献者图片
- 🤖 图片会自动从 GitHub API 获取最新的贡献者信息
- 📸 自动获取贡献者的 GitHub 头像
- 🔧 添加了 GitHub Action 工作流文件（用于文档说明）

## 优势

1. **完全自动化**：无需手动更新贡献者列表
2. **实时更新**：总是显示最新的贡献者信息
3. **准确信息**：直接从 GitHub 获取，避免信息错误
4. **美观展示**：以图片形式展示所有贡献者

## 效果预览

贡献者列表将显示为一个包含所有贡献者头像的图片，点击可跳转到贡献者页面。

## 测试

- 图片链接：https://contrib.rocks/image?repo=aki66938/xhs-toolkit
- 可以在浏览器中预览效果