### PR TITLE
fix: 修复 Windows 上 pydantic-core 构建错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ uv run python xhs_toolkit.py status  ## 验证工具是否可用
 ```
 
 > 💡 **uv使用提示**：文档中所有 `python` 命令都可以用 `uv run python` 替代，享受更快的依赖管理体验！
+>
+> ⚠️ **Windows 用户注意**：如遇到构建错误，请参考 [Windows 安装指南](docs/windows-installation.md)
 
 #### 方法二：pip (传统方式)
 

--- a/docs/windows-installation.md
+++ b/docs/windows-installation.md
@@ -1,0 +1,69 @@
+# Windows 安装指南
+
+## 已知问题
+
+### uv 构建错误 ([Issue #7](https://github.com/aki66938/xhs-toolkit/issues/7))
+
+在 Windows 上使用 `uv` 安装时可能遇到以下错误：
+
+```
+Failed to build `pydantic-core==2.33.2`
+maturin failed: A python 3 interpreter on Linux or macOS must define abiflags in its sysconfig
+```
+
+这是由于 pydantic 2.11+ 版本依赖的 pydantic-core (2.33.2) 在 Windows 上通过 uv 构建时的兼容性问题。maturin 构建工具错误地期望 Windows Python 有 `sys.abiflags`（这是 Unix/Linux 特有的属性）。
+
+## 解决方案
+
+### 方案 1：使用 Windows 专用依赖文件（推荐）
+
+使用专门为 Windows 准备的依赖文件，其中限制了 pydantic 版本：
+
+```bash
+# 使用 pip
+pip install -r requirements-windows.txt
+
+# 或使用 uv
+uv pip install -r requirements-windows.txt
+```
+
+### 方案 2：使用预编译包
+
+如果需要使用最新版本的 pydantic，可以：
+
+1. 先安装预编译的 wheel 包：
+```bash
+pip install pydantic --only-binary :all:
+```
+
+2. 再安装项目：
+```bash
+pip install -e .
+```
+
+### 方案 3：使用 conda
+
+使用 conda 可以避免构建问题：
+
+```bash
+conda create -n xhs python=3.10
+conda activate xhs
+conda install pydantic
+pip install -e .
+```
+
+## ChromeDriver 配置
+
+Windows 上的 ChromeDriver 配置示例：
+
+```bash
+# .env 文件
+CHROME_PATH="C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+WEBDRIVER_CHROME_DRIVER="C:\\tools\\chromedriver.exe"
+```
+
+## 其他注意事项
+
+1. 确保 Python 版本 >= 3.10
+2. 建议使用虚拟环境
+3. ChromeDriver 版本需要与 Chrome 浏览器版本匹配

--- a/requirements-windows.txt
+++ b/requirements-windows.txt
@@ -1,0 +1,18 @@
+# Windows 专用依赖文件
+# 解决 pydantic-core 在 Windows 上的构建问题
+# 参见: https://github.com/aki66938/xhs-toolkit/issues/7
+
+fastmcp>=2.0.0
+requests>=2.31.0
+aiohttp>=3.9.0
+fastapi>=0.104.0
+uvicorn>=0.24.0
+selenium>=4.15.0
+pydantic>=2.5.0,<2.11.0  # 限制版本以避免 Windows 构建问题
+python-multipart>=0.0.6
+pandas>=2.0.0
+cryptography>=41.0.0
+pycryptodome>=3.19.0
+python-dotenv>=1.0.0
+loguru>=0.7.2
+apscheduler>=3.10.0


### PR DESCRIPTION
## 问题描述

修复 #7 - Windows 用户在使用 `uv` 安装时遇到 pydantic-core 2.33.2 构建错误：

```
Failed to build `pydantic-core==2.33.2`
maturin failed: A python 3 interpreter on Linux or macOS must define abiflags in its sysconfig
```

## 根本原因

pydantic 2.11+ 依赖的 pydantic-core 使用 maturin 构建 Rust 扩展时，错误地期望 Windows Python 有 `sys.abiflags`（这是 Unix/Linux 特有的属性）。

## 解决方案

提供 Windows 专用的依赖文件，限制 pydantic 版本到 2.11 以下：

1. **创建 `requirements-windows.txt`**：专门为 Windows 用户准备，其中 pydantic 版本限制为 `>=2.5.0,<2.11.0`
2. **添加 Windows 安装指南**：详细说明问题和多种解决方案
3. **更新 README**：提醒 Windows 用户查看专门的安装指南

## 测试请求

@oemby 请帮忙在 Windows 环境下测试以下安装方式是否能解决问题：

```bash
# 方式 1：使用 pip
pip install -r requirements-windows.txt

# 方式 2：使用 uv
uv pip install -r requirements-windows.txt
```

由于我没有 Windows 环境，需要您的帮助验证这个解决方案是否有效。谢谢！

## 其他说明

- 这是一个临时解决方案，待 pydantic-core 或 maturin 修复 Windows 兼容性问题后可以移除版本限制
- 不影响其他平台用户，主项目的 `pyproject.toml` 保持不变