### PR TITLE
feat: 添加查看cookie字符串格式功能

### DIFF
--- a/src/auth/cookie_manager.py
+++ b/src/auth/cookie_manager.py
@@ -702,6 +702,50 @@ class CookieManager:
         except Exception as e:
             logger.error(f"❌ 读取cookies失败: {e}")
     
+    def display_cookies_string(self) -> None:
+        """显示cookies字符串格式（可复制）"""
+        cookies_file = Path(self.config.cookies_file)
+        
+        if not cookies_file.exists():
+            logger.warning("❌ Cookies文件不存在")
+            return
+        
+        try:
+            with open(cookies_file, 'r', encoding='utf-8') as f:
+                cookies_data = json.load(f)
+            
+            # 兼容新旧格式
+            if isinstance(cookies_data, list):
+                cookies = cookies_data
+            else:
+                cookies = cookies_data.get('cookies', [])
+            
+            if not cookies:
+                print("❌ 没有找到cookies")
+                return
+            
+            print("🍪 Cookies字符串格式（可复制）:")
+            print("=" * 60)
+            
+            # 构建cookie字符串
+            cookie_strings = []
+            for cookie in cookies:
+                name = cookie.get('name', '')
+                value = cookie.get('value', '')
+                if name and value:
+                    cookie_strings.append(f"{name}={value}")
+            
+            # 显示完整的cookie字符串
+            cookie_string = "; ".join(cookie_strings)
+            print(f"\n{cookie_string}\n")
+            
+            print("=" * 60)
+            print(f"📊 总共 {len(cookie_strings)} 个cookies")
+            print("💡 提示: 可以复制上面的字符串在其他地方使用")
+            
+        except Exception as e:
+            logger.error(f"❌ 读取cookies失败: {e}")
+    
     @handle_exception
     def validate_cookies(self) -> bool:
         """

--- a/xhs_toolkit.py
+++ b/xhs_toolkit.py
@@ -79,6 +79,10 @@ def cookie_command(action: str) -> bool:
             cookie_manager.display_cookies_info()
             return True
             
+        elif action == "string":
+            cookie_manager.display_cookies_string()
+            return True
+            
         elif action == "validate":
             result = cookie_manager.validate_cookies()
             if result:
@@ -95,7 +99,7 @@ def cookie_command(action: str) -> bool:
             
         else:
             safe_print(f"❌ 未知操作: {action}")
-            safe_print("💡 可用操作: save, show, validate, test")
+            safe_print("💡 可用操作: save, show, string, validate, test")
             return False
             
     except XHSToolkitError as e:
@@ -414,7 +418,7 @@ def main():
     
     # Cookie管理命令
     cookie_parser = subparsers.add_parser("cookie", help="Cookie管理")
-    cookie_parser.add_argument("action", choices=["save", "show", "validate", "test"], 
+    cookie_parser.add_argument("action", choices=["save", "show", "string", "validate", "test"], 
                               help="操作类型")
     
     # 服务器管理命令

--- a/xhs_toolkit_interactive.py
+++ b/xhs_toolkit_interactive.py
@@ -279,12 +279,13 @@ class InteractiveMenu:
 
 1. 🍪 获取新的Cookies
 2. 👀 查看Cookies信息
-3. ✅ 验证Cookies有效性
-4. 🧪 测试ChromeDriver
+3. 📋 查看Cookies字符串格式
+4. ✅ 验证Cookies有效性
+5. 🧪 测试ChromeDriver
 0. 返回主菜单
 
 """)
-            choice = input("请选择操作 (0-4): ").strip()
+            choice = input("请选择操作 (0-5): ").strip()
             
             script_dir = Path(__file__).parent
             
@@ -307,6 +308,12 @@ class InteractiveMenu:
                 cookie_manager.display_cookies_info()
                 input("\n按回车键继续...")
             elif choice == "3":
+                safe_print("\n📋 查看Cookies字符串格式...")
+                from src.auth.cookie_manager import CookieManager
+                cookie_manager = CookieManager(self.config)
+                cookie_manager.display_cookies_string()
+                input("\n按回车键继续...")
+            elif choice == "4":
                 safe_print("\n✅ 验证Cookies...")
                 from src.auth.cookie_manager import CookieManager
                 cookie_manager = CookieManager(self.config)
@@ -316,7 +323,7 @@ class InteractiveMenu:
                 else:
                     safe_print("\n❌ Cookies验证失败，建议重新获取")
                 input("\n按回车键继续...")
-            elif choice == "4":
+            elif choice == "5":
                 safe_print("\n🧪 测试ChromeDriver...")
                 from src.auth.cookie_manager import CookieManager
                 cookie_manager = CookieManager(self.config)


### PR DESCRIPTION
## Summary
- 添加了查看cookie字符串格式的功能，方便用户复制cookie用于手动API调用
- 在交互式菜单和命令行工具中都添加了相应的入口

## Changes
- 在 `CookieManager` 中添加 `display_cookies_string()` 方法
- 支持将cookies导出为可复制的字符串格式: `name1=value1; name2=value2`
- 在交互式菜单中添加"查看Cookies字符串格式"选项
- 在命令行工具中添加 `cookie string` 命令

## Test plan
- [x] 测试交互式菜单中的"查看Cookies字符串格式"功能
- [x] 测试命令行 `python xhs_toolkit.py cookie string`
- [x] 验证输出的cookie字符串格式正确
- [x] 确认可以复制并在其他工具中使用