### PR TITLE
Feature/fix bug：修复mcp_server的异步bug 和 Chrome数据存储路径问题

### DIFF
--- a/src/core/browser.py
+++ b/src/core/browser.py
@@ -156,7 +156,10 @@ class ChromeDriverManager:
         chrome_options.add_argument('--window-size=1920,1080')
 
         # 添加文件保存位置
-        chrome_options.add_argument(f'--user-data-dir=/home/seluser/google-chrome-data')
+        home_dir = os.path.expanduser("~")
+        # 创建一个专门用于存放chrome数据的文件夹路径
+        profile_path = os.path.join(home_dir, "xhs-toolkit-chrome-data")
+        chrome_options.add_argument(f'--user-data-dir={profile_path}')
         
         # 调试选项
         if self.config.debug_mode:

--- a/src/core/browser.py
+++ b/src/core/browser.py
@@ -6,6 +6,7 @@
 
 import asyncio
 import time
+import os
 from typing import Optional, List, Dict, Any
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options

--- a/src/server/mcp_server.py
+++ b/src/server/mcp_server.py
@@ -836,7 +836,7 @@ class MCPServer:
         
         # 使用stdio transport
         logger.info("🎯 MCP工具已注册，等待客户端连接...")
-        self.mcp.run_async(transport="stdio")
+        await self.mcp.run_async(transport="stdio")
     
     async def start(self) -> None:
         """启动MCP服务器"""
@@ -905,7 +905,7 @@ class MCPServer:
             logging.getLogger("uvicorn").setLevel(logging.WARNING)
             logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
             
-            self.mcp.run_async(transport="sse", port=self.config.server_port, host=self.config.server_host)
+            await self.mcp.run_async(transport="sse", port=self.config.server_port, host=self.config.server_host)
             
         except KeyboardInterrupt:
             logger.info("👋 收到停止信号，正在关闭服务器...")

--- a/src/server/mcp_server.py
+++ b/src/server/mcp_server.py
@@ -782,7 +782,7 @@ class MCPServer:
         signal.signal(signal.SIGINT, signal_handler)
         signal.signal(signal.SIGTERM, signal_handler)
     
-    def start_stdio(self) -> None:
+    async def start_stdio(self) -> None:
         """启动stdio模式的MCP服务器（用于Claude Desktop）"""
         # 设置日志只输出到stderr，避免干扰stdio通信
         import sys
@@ -823,7 +823,12 @@ class MCPServer:
                 logger.info("📊 初始化数据采集功能...")
                 # stdio模式下使用无头浏览器
                 self.xhs_client.browser_manager.headless = True
-                self.scheduler_initialized = self._initialize_data_collection()
+                await self._initialize_data_collection()
+
+                if self.scheduler_initialized:
+                    logger.info("✅ 数据采集功能初始化完成")
+                else:
+                    logger.info("ℹ️ 数据采集功能未启用或初始化失败")
             else:
                 logger.info("ℹ️ 数据采集功能未启用")
         except Exception as e:
@@ -831,9 +836,9 @@ class MCPServer:
         
         # 使用stdio transport
         logger.info("🎯 MCP工具已注册，等待客户端连接...")
-        self.mcp.run(transport="stdio")
+        self.mcp.run_async(transport="stdio")
     
-    def start(self) -> None:
+    async def start(self) -> None:
         """启动MCP服务器"""
         logger.info("🚀 启动小红书 MCP 服务器...")
         
@@ -886,7 +891,7 @@ class MCPServer:
         # 初始化数据采集功能（无头模式）
         logger.info("📊 初始化数据采集功能（无头模式）...")
         try:
-            asyncio.run(self._initialize_data_collection())
+            await self._initialize_data_collection()
             if self.scheduler_initialized:
                 logger.info("✅ 数据采集功能初始化完成（无头模式）")
             else:
@@ -900,7 +905,7 @@ class MCPServer:
             logging.getLogger("uvicorn").setLevel(logging.WARNING)
             logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
             
-            self.mcp.run(transport="sse", port=self.config.server_port, host=self.config.server_host)
+            self.mcp.run_async(transport="sse", port=self.config.server_port, host=self.config.server_host)
             
         except KeyboardInterrupt:
             logger.info("👋 收到停止信号，正在关闭服务器...")
@@ -950,10 +955,10 @@ def main():
     # 检查是否通过stdio启动（Claude Desktop使用）
     if len(sys.argv) > 1 and sys.argv[1] == "--stdio":
         # 使用stdio模式
-        server.start_stdio()
+        asyncio.run(server.start_stdio())
     else:
         # 默认使用SSE模式（用于其他客户端）
-        server.start()
+        asyncio.run(server.start())
 
 
 if __name__ == "__main__":

--- a/xhs_toolkit.py
+++ b/xhs_toolkit.py
@@ -14,6 +14,7 @@ import time
 import asyncio
 from pathlib import Path
 
+
 # 导入重构后的模块
 from src.core.config import XHSConfig
 from src.core.exceptions import XHSToolkitError, format_error_message
@@ -133,7 +134,8 @@ def server_command(action: str, port: int = 8000, host: str = "0.0.0.0") -> bool
             # 初始化配置和服务器
             config = XHSConfig()
             server = MCPServer(config)
-            server.start()
+            # 使用asyncio.run来运行异步的start方法
+            asyncio.run(server.start())
             return True
             
         except KeyboardInterrupt:


### PR DESCRIPTION
## 🐞 已知问题（Bugs）

### Bug 1: Chrome数据存储路径问题
- 相关 Issue：[#24 ](https://github.com/aki66938/xhs-toolkit/issues/24)

### Bug 2: 事件循环冲突导致定时器失效
- 相关 Issue：[#41 ](https://github.com/aki66938/xhs-toolkit/issues/41)
- 文件位置：`mcp_server.py`

#### ❌ 问题描述
在 `mcp_server.py` 中：
- 对 `self._initialize_data_collection()` 添加了事件循环支持；
- 但服务器启动方式为同步调用 `self.mcp.run`；
- 导致用于定时器的事件循环被提前关闭，任务无法正常执行。

#### ✅ 解决方案
将**服务器启动**过方式异步调用，
将以下两个操作均改为**异步调用**，并添加到**同一个事件循环**中：